### PR TITLE
[PROBLEM-11] leetcode - Max Area of island.js

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+    "printWidth": 80
+}

--- a/javascript/problems/leetcode/695. Max Area of Island.js
+++ b/javascript/problems/leetcode/695. Max Area of Island.js
@@ -1,0 +1,66 @@
+const directions = [[1, 0], [-1, 0], [0, 1], [0, -1]];
+
+const maxAreaOfIsland = grid => {
+    const rowLength = grid.length;
+    const colLength = grid[0].length;
+
+    let answer = 0;
+
+    for (let i = 0; i < grid.length; i += 1) {
+        for (let j = 0; j < grid[0].length; j += 1) {
+            const queue = [];
+            let cnt = 0;
+
+            if (grid[i][j] === 1) {
+                queue.push([i, j])
+            }
+
+            while (queue.length) {
+                const [x, y] = queue.shift();
+
+                if (!grid[x][y]) continue;
+                grid[x][y] = 0;
+                cnt += 1;
+                
+                for (let i = 0; i < 4; i += 1) {
+                    const [dx, dy] = directions[i];
+                    const nx = x + dx;
+                    const ny = y + dy;
+
+                    if (nx < 0 || ny < 0 || nx >= rowLength || ny >= colLength || !grid[nx][ny]) continue;
+                    queue.push([nx, ny])
+                }
+            }
+
+            answer = Math.max(answer, cnt)
+        }
+    }
+    return answer;
+};
+
+(() => {
+    const grid = [
+        [0,0,1,0,0,0,0,1,0,0,0,0,0],
+        [0,0,0,0,0,0,0,1,1,1,0,0,0],
+        [0,1,1,0,1,0,0,0,0,0,0,0,0],
+        [0,1,0,0,1,1,0,0,1,0,1,0,0],
+        [0,1,0,0,1,1,0,0,1,1,1,0,0],
+        [0,0,0,0,0,0,0,0,0,0,1,0,0],
+        [0,0,0,0,0,0,0,1,1,1,0,0,0],
+        [0,0,0,0,0,0,0,1,1,0,0,0,0]
+    ];
+
+    console.log(maxAreaOfIsland(grid));
+})();
+
+
+(() => {
+    const grid = [
+        [1,1,0,0,0],
+        [1,1,0,0,0],
+        [0,0,0,1,1],
+        [0,0,0,1,1]
+    ]
+
+    console.log(maxAreaOfIsland(grid));
+})();


### PR DESCRIPTION
## ⚠️ 연결된 이슈를 적어주세요!
closes #11 


## ❓ 문제의 출처는 어디인가요? 
> (ex: 프로그래머스, 백준, leetcode ...)

leetcode

## 🌟 문제 제목은 무엇인가요?

[695. Max Area of Island](https://leetcode.com/problems/max-area-of-island/)

## 🕰 문제를 푸는 데 걸린 시간은 어떠했나요? 

10분

## ✨ 풀이 과정에 대해서 설명해봅시다.


### 💥 문제의 핵심 알고리즘

매우 전형적인 `BFS`, `DFS` 알고리즘이며, 저의 경우 자신 있는 `BFS`로 구현했습니다.

### 🔥 상세 풀이 과정

> 1. for문으로 순회를 한다.
> 2. 순회를 할 때마다 만약 1이 카운트되어 있다면 큐에 집어넣는다.
> 3. 큐가 빌 때까지 4방향으로 1이된 곳을 찾아서 0으로 바꿔준다.
> 4. 섬의 크기를 카운트해주어, 현재 `answer`값과 비교한 후, 업데이트한다.
> 5. 결과를 반환한다.

## 💎 배운 점, 그리고 제대로 숙지하지 못했던 점

### 🌙 배운 점

### 💧 제대로 숙지하지 못했던 점

`BFS`의 `visited`를 제대로 체크하지 못했던 점을 반성한다.
맨 처음에 제한시간을 초과하는 이슈가 발생했다. 이슈를 추적해보니, `BFS`에서 이미 `visited` 되었음에도 불구하고 중복해서 큐에 집어넣었기 때문에 발생한 이슈였다. 

나의 경우 업데이트를 큐에서 뺀 후 다시 업데이트하는 로직이었기에, 따라서 이를 해결하기 위해서는 뺐을 때 이미 계산이 되었는지를 카운트하는 로직을 넣어야 했다.

항상 방심하지 말고, 내가 넣어야 할 큐값을 정확히 넣었는지, 그리고 중복해서 큐에 넣어지는지를 꼼꼼히 판단해야겠다.