### PR TITLE
[PROBLEM-20] 프로그래머스 - 방문 길이

### DIFF
--- a/javascript/problems/programmers/방문 길이.js
+++ b/javascript/problems/programmers/방문 길이.js
@@ -1,0 +1,45 @@
+const solution = (dirs) => {
+  const directions = {
+    U: [0, -1],
+    L: [-1, 0],
+    D: [0, 1],
+    R: [1, 0]
+  };
+  
+  let answer = 0;
+  const visited = new Set();
+  
+  let x = 0; 
+  let y = 0;
+
+  [...dirs].forEach(dir => {
+      const [dx, dy] = directions[dir];
+      const nx = x + dx;
+      const ny = y + dy;
+
+      const stringifiedVisitedEdge = JSON.stringify([x, y, nx, ny]);
+      const checkVisitedValues = [stringifiedVisitedEdge, JSON.stringify([nx, ny, x, y])]
+
+      if (nx > 5 || nx < -5 || ny > 5 || ny < -5 ) return;
+
+      x = nx;
+      y = ny;
+
+      if (!checkVisitedValues.some(value => visited.has(value))) {
+        visited.add(stringifiedVisitedEdge)      
+        answer += 1;
+      }
+  })
+  
+  return answer;
+}
+
+(() => {
+  const dirs = "ULURRDLLU"
+  console.log(solution(dirs))
+})();
+
+(() => {
+  const dirs = "LULLLLLLU"
+  console.log(solution(dirs))
+})();


### PR DESCRIPTION
## ⚠️ 연결된 이슈를 적어주세요!
closes #20 


## ❓ 문제의 출처는 어디인가요? 
> (ex: 프로그래머스, 백준, leetcode ...)

프로그래머스 

## 🌟 문제 제목은 무엇인가요?

[방문 길이](https://programmers.co.kr/learn/courses/30/lessons/49994)

## 🕰 문제를 푸는 데 걸린 시간은 어떠했나요? 

20분

## ✨ 풀이 과정에 대해서 설명해봅시다.

### 💥 문제의 핵심 알고리즘

어떻게 방문했는지를 처리하는 것만 신경 쓰면 어렵지 않은 단순 구현 문제. 
효율성도, 정확성도 딱히 어려울 게 없었다.

### 🔥 상세 풀이 과정
> 1. 예시
> 2. BFS를 통해 큐를 순회하며 주어진 값들을 `result`에 넣는다.
> 3. 결과 값을 반환한다.

1. 핵심은 어떻게 방문했는지를 체크하는 방법이다.
2. 이에 관해서는 3차원 배열 등 다양한 방법이 있겠지만, 나의 경우는 `Set` 자료구조를 썼다.
3. 그 이유는, 그저 `stringify`된 경로만 체크해주면 되는데, 이는 단순 배열로 구현하면 O(N)이 추가로 소요되지만 Set에서의 검색은 logN이기 때문이다.
4. visited를 구현했다면, 일단 먼저 x, y가 보드를 넘어가는지를 체크한다.
5. 넘어가면 리턴, 아니라면 방문했는지 여부를 검사한다.
6. 만약 방문 역시 하지 않았다면 answer과 visited를 업데이트, 아니라면 x, y값만 업데이트하고 리턴한다.
7. 이를 계속해서 반복하고, 결과를 리턴한다.

## 💎 배운 점, 그리고 제대로 숙지하지 못했던 점


### 🌙 배운 점


### 💧 제대로 숙지하지 못했던 점