### PR TITLE
:white_check_mark: [PROBLE-157] Leetcode - 328. Odd Even Linked List

### DIFF
--- a/javascript/problems/leetcode/328. Odd Even Linked List.js
+++ b/javascript/problems/leetcode/328. Odd Even Linked List.js
@@ -1,0 +1,19 @@
+function oddEvenList(arr) {
+  for (let value of genList()) {
+    console.log(value);
+  }
+
+  function* genList() {
+    let idx = 0;
+
+    while (idx < arr.length) {
+      yield arr[idx];
+      idx += 2;
+    }
+  }
+
+  return -1;
+}
+
+const arr = [1, 2, 3, 4, 5, 6, 7, 8];
+console.log(oddEvenList(arr));

--- a/javascript/problems/leetcode/328. Odd Even LinkedList.js
+++ b/javascript/problems/leetcode/328. Odd Even LinkedList.js
@@ -1,0 +1,35 @@
+/**
+ * Definition for singly-linked list.
+ * function ListNode(val, next) {
+ *     this.val = (val===undefined ? 0 : val)
+ *     this.next = (next===undefined ? null : next)
+ * }
+ */
+
+/**
+ * @param {ListNode} head
+ * @return {ListNode}
+ */
+/**
+ * 1. 결과적으로 홀수를 앞에다 놓는다.
+ * 2. 새롭게 나온 짝수를 머리로 설정하고, 홀수의 다음을 기존 짝수 머리와 연결한다.
+ */
+function oddEvenList(head) {
+  if (head === null) return head;
+
+  const evenHead = head.next;
+  let odd = head;
+
+  while (odd?.next?.next) {
+    const even = odd.next;
+
+    odd.next = odd.next.next;
+    odd = odd.next;
+
+    even.next = even.next.next;
+  }
+
+  odd.next = evenHead;
+
+  return head;
+}


### PR DESCRIPTION
## ⚠️ 연결된 이슈를 적어주세요!
closes #156 


## ❓ 문제의 출처는 어디인가요? 

leetcode

## 🌟 문제 제목은 무엇인가요?

328. Odd Even Linked List

## 🕰 문제를 푸는 데 걸린 시간은 어떠했나요? 

30분...?

## ✨ 풀이 과정에 대해서 설명해봅시다.


### 💥 문제의 핵심 알고리즘

양방향 연결 리스트

### 🔥 상세 풀이 과정
상세 첨부된 이슈를 참조합니다 😝

## 💎 배운 점, 그리고 제대로 숙지하지 못했던 점


### 🌙 배운 점

#### 나의 단점: 너무 '익숙하게' 문제를 풀려했다. 그리고 이것이 최선인지 검토하지 않았다.

내가 원래 생각했던 로직은 배열에 각 노드를 캐싱해주어 문제를 해결하는 방법이었다.
하지만 그렇게 하지 않아도 되었다. 결과적으로 노드들은 변수에 참조되는 한 가비지 컬렉션에서 제거되지 않는다.
이를 이용하여 짝수는 그저 다음 짝수 노드로 이어주고, 홀수는 다음 홀수 노드로 이어주면 된다.

결과적으로 배열을 캐싱해두지 않고 순회 한 번에 끝내버리니, 시간 복잡도를 70% 개선했다.
만약 이 결과를 다른 동료들과 비교하지 않았더라면 그저 넘어가지 않았을까.
**최근에 시간이 없다는 핑계로 기존의 결과들이 최선인지 비교하지 않았던 행위를 반성하게 되었다.**

### 💧 제대로 숙지하지 못했던 점
